### PR TITLE
feat(roc-plugin-style-css): Export the ExtractText plugin as a dependency

### DIFF
--- a/plugins/roc-plugin-style-css/src/roc/index.js
+++ b/plugins/roc-plugin-style-css/src/roc/index.js
@@ -1,14 +1,19 @@
 import { isArray, isObject, isString, oneOf } from 'roc/validators';
-import { lazyFunctionRequire } from 'roc';
+import { lazyFunctionRequire, generateDependencies } from 'roc';
 
 import config from '../config/roc.config.js';
 import meta from '../config/roc.config.meta.js';
+
+import { packageJSON } from './util';
 
 const lazyRequire = lazyFunctionRequire(require);
 
 export default {
     config,
     meta,
+    dependencies: {
+        exports: generateDependencies(packageJSON, ['extract-text-webpack-plugin']),
+    },
     actions: [{
         hook: 'build-webpack',
         description: 'Adds CSS support.',

--- a/plugins/roc-plugin-style-css/src/roc/util.js
+++ b/plugins/roc-plugin-style-css/src/roc/util.js
@@ -1,6 +1,6 @@
 import { runHook } from 'roc';
 
-const packageJSON = require('../../package.json');
+export const packageJSON = require('../../package.json');
 
 /**
  * Helper function for invoking/running a hook, pre-configured for the current package.


### PR DESCRIPTION
Certain projects may depend on the ExtractText plugin implicitly – this ensures the plugin is available.