### PR TITLE
chore: Use Node 6 when running in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ cache:
   directories:
     - node_modules
 node_js:
-  - 4
+  - 6
 before_install:
   - npm install -g npm@5
 before_script:


### PR DESCRIPTION
This will make Travis work as it should, needed since `roc-plugin-repo` has a requirement on Node 6.